### PR TITLE
:zap: Added API Rate Limit as described in issue 56

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,6 +35,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/schedule": "^4.0.0",
     "@nestjs/swagger": "^7.1.14",
+    "@nestjs/throttler": "^5.1.1",
     "@ntegral/nestjs-sentry": "^4.0.0",
     "@prisma/client": "^5.4.2",
     "@sentry/node": "^7.80.0",


### PR DESCRIPTION
Added API Rate Limit as described in issue 56, Used nest js package throttle for applying rate limit to APIs the throttle limit and throttle ttl are to be added in .env as THROTTLER_LIMIT and THROTTLE_TTL respectively.