### PR TITLE
:memo: Fix Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Your customers expect all of their tools to work well together. Panora avoids yo
   docker compose up
  ```
 
-You can now open your browser and go to <http://localhost> to connect to the application.
+You can now open your browser and go to <http://localhost:80> to connect to the application.
 Visit our [Quickstart Guide](https://docs.panora.dev/quick-start) to start adding integrations to your product
 
 ## 🤔 Have questions? Ask the core team

--- a/docs/features/self-host-guide.mdx
+++ b/docs/features/self-host-guide.mdx
@@ -34,7 +34,7 @@ cd Panora && cp .env.example .env
   ```bash
 docker ps
 ```
-After a few minutes Panora's dashboard will be available at `http://localhost`.
+After a few minutes Panora's dashboard will be available at `http://localhost:80`.
 The backend runs on `http://localhost:3000`
 
 **Congrats, Panora is now ready 🍾🔥**


### PR DESCRIPTION
This should be `localhost:80` (frontend-webapp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the connection instructions in the README and self-host guide with the correct port number for accessing the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->