### PR TITLE
Fix the 'AddLinkedUser' dialog from configuration Page

### DIFF
--- a/apps/webapp/src/components/configuration/components/AddLinkedAccount.tsx
+++ b/apps/webapp/src/components/configuration/components/AddLinkedAccount.tsx
@@ -76,6 +76,7 @@ const AddLinkedAccount = () => {
     defaultValues: {
       linkedUserIdentifier: "",
     },
+    
   })
 
   function onSubmit(values: z.infer<typeof formSchema>) {
@@ -90,6 +91,7 @@ const AddLinkedAccount = () => {
       id_project: idProject,
       mode: config.DISTRIBUTION
     })
+    form.reset()
   }
 
 
@@ -161,7 +163,7 @@ const AddLinkedAccount = () => {
             {showNewLinkedUserDialog.import ? "You can upload a sheet of your existing linked users" : "Add a new linked user to your project"}
           </DialogDescription>
         </DialogHeader>
-        <Form {...form}>
+        <Form {...form} >
         <form onSubmit={form.handleSubmit(onSubmit)}>
         <div>
           <div className="space-y-4 py-2 pb-4">
@@ -199,7 +201,7 @@ const AddLinkedAccount = () => {
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setShowNewLinkedUserDialog({open: false})}>
+          <Button variant="outline" type='reset' onClick={() => {form.reset();setShowNewLinkedUserDialog({open: false})}}>
             Cancel
           </Button>
           <Button variant="outline" type="submit">{showNewLinkedUserDialog.import ? "Import" : "Create"}</Button>


### PR DESCRIPTION
### Problems to be fixed by this PR
- The new LinkedUser was added by clicking the Cancel button of 'AddLinkedUser' dialog on the Configuration Page
- The form displays the old value of the orgin-identifier from a previously submitted form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the user experience in the configuration settings by allowing linked accounts to be added more seamlessly.
- **Bug Fixes**
	- Fixed an issue where the form fields were not resetting after submission.
- **Refactor**
	- Improved form handling in the configuration settings for better user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->