### PR TITLE
Add pagination for events table

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -51,6 +51,7 @@
     "sonner": "^1.4.0",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-query-params": "^2.2.1",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"
   },

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,6 +1,8 @@
 import './App.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import LogsPage from './components/events';
 import ConnectionsPage from './components/connections';
 import TaskPage from './components/events/EventsTable';
@@ -33,17 +35,19 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme='dark' storageKey='vite-ui-theme'>
         <Router>
-          <Routes>
-            <Route path='/' element={<RootLayout />}>
-              <Route index element={<ConnectionsPage />} />
-              <Route path='/dashboard' element={<DashboardPage />} />
-              <Route path='/logs' element={<LogsPage />} />
-              <Route path='/tasks' element={<TaskPage />} />
-              <Route path='/configuration' element={<ConfigurationPage />} />
-              <Route path='/connections' element={<ConnectionsPage />} />
-              <Route path='/api-keys' element={<ApiKeysPage />} />
-            </Route>
-          </Routes>
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path='/' element={<RootLayout />}>
+                <Route index element={<ConnectionsPage />} />
+                <Route path='/dashboard' element={<DashboardPage />} />
+                <Route path='/logs' element={<LogsPage />} />
+                <Route path='/tasks' element={<TaskPage />} />
+                <Route path='/configuration' element={<ConfigurationPage />} />
+                <Route path='/connections' element={<ConnectionsPage />} />
+                <Route path='/api-keys' element={<ApiKeysPage />} />
+              </Route>
+            </Routes>
+          </QueryParamProvider>
         </Router>
       </ThemeProvider>
     </QueryClientProvider>

--- a/apps/webapp/src/components/api-data-table-pagination.tsx
+++ b/apps/webapp/src/components/api-data-table-pagination.tsx
@@ -1,0 +1,84 @@
+import { ChevronLeftIcon, ChevronRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from '@radix-ui/react-icons';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Button } from './ui/button';
+
+import { type UseQueryPaginationReturn } from '@/hooks/use-query-pagination';
+
+interface DataTablePaginationProps extends UseQueryPaginationReturn {
+  selected: number;
+  isLoading: boolean;
+}
+
+export function ApiDataTablePagination(props: DataTablePaginationProps) {
+  return (
+    <div className='flex items-center justify-between px-2'>
+      <div className='flex-1 text-sm text-muted-foreground'>
+        {props.selected} of {props.totalItems} row(s) selected.
+      </div>
+      <div className='flex items-center space-x-6 lg:space-x-8'>
+        <div className='flex items-center space-x-2'>
+          <p className='text-sm font-medium'>Rows per page</p>
+          <Select
+            disabled={props.totalItems <= 10 || props.isLoading}
+            value={`${props.pageSize}`}
+            onValueChange={(value) => {
+              props.setPageSize(Number(value));
+            }}
+          >
+            <SelectTrigger className='h-8 w-[70px]'>
+              <SelectValue placeholder={props.pageSize} />
+            </SelectTrigger>
+            <SelectContent side='top'>
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <SelectItem key={pageSize} value={`${pageSize}`}>
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className='flex w-[100px] items-center justify-center text-sm font-medium'>
+          Page {props.page} of {props.totalPages}
+        </div>
+        <div className='flex items-center space-x-2'>
+          <Button
+            variant='outline'
+            className='hidden h-8 w-8 p-0 lg:flex'
+            onClick={() => props.resetPage()}
+            disabled={!props.previousEnabled || props.isLoading}
+          >
+            <span className='sr-only'>Go to first page</span>
+            <DoubleArrowLeftIcon className='h-4 w-4' />
+          </Button>
+          <Button
+            variant='outline'
+            className='h-8 w-8 p-0'
+            onClick={() => props.setPreviousPage()}
+            disabled={!props.previousEnabled || props.isLoading}
+          >
+            <span className='sr-only'>Go to previous page</span>
+            <ChevronLeftIcon className='h-4 w-4' />
+          </Button>
+          <Button
+            variant='outline'
+            className='h-8 w-8 p-0'
+            onClick={() => props.setNextPage()}
+            disabled={!props.nextEnabled || props.isLoading}
+          >
+            <span className='sr-only'>Go to next page</span>
+            <ChevronRightIcon className='h-4 w-4' />
+          </Button>
+          <Button
+            variant='outline'
+            className='hidden h-8 w-8 p-0 lg:flex'
+            onClick={() => props.setPage(props.totalPages)}
+            disabled={!props.nextEnabled || props.isLoading}
+          >
+            <span className='sr-only'>Go to last page</span>
+            <DoubleArrowRightIcon className='h-4 w-4' />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/api-data-table.tsx
+++ b/apps/webapp/src/components/api-data-table.tsx
@@ -1,0 +1,102 @@
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+  VisibilityState,
+} from '@tanstack/react-table';
+import { useState } from 'react';
+
+import { ApiDataTablePagination } from './api-data-table-pagination';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import { LoadingSpinner } from './connections/components/LoadingSpinner';
+
+import { type UseQueryPaginationReturn } from '@/hooks/use-query-pagination';
+
+interface DataTableProps<TData, TValue> extends UseQueryPaginationReturn {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  isLoading: boolean;
+}
+export function ApiDataTable<TData, TValue>({
+  columns,
+  data,
+  isLoading,
+  ...paginationProps
+}: DataTableProps<TData, TValue>) {
+  const [rowSelection, setRowSelection] = useState({});
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnVisibility,
+      rowSelection,
+    },
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  });
+
+  return (
+    <div className='space-y-4'>
+      <div className='relative overflow-hidden rounded-md border'>
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className='h-24 text-center'>
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+
+        {isLoading && (
+          <div className='absolute left-0 top-0 flex h-full w-full items-center justify-center bg-background/50 backdrop-blur-sm'>
+            <LoadingSpinner className='' />
+          </div>
+        )}
+      </div>
+      <ApiDataTablePagination
+        selected={table.getSelectedRowModel().rows.length}
+        isLoading={isLoading}
+        {...paginationProps}
+      />
+    </div>
+  );
+}

--- a/apps/webapp/src/components/events/EventsTable.tsx
+++ b/apps/webapp/src/components/events/EventsTable.tsx
@@ -1,11 +1,25 @@
 import { columns } from "./components/columns"
-import { DataTable } from "../shared/data-table"
+import { ApiDataTable } from '../api-data-table';
 import useEvents from "@/hooks/useEvents";
 import { DataTableLoading } from "../shared/data-table-loading";
 import { events as Event } from "api";
+import { useEventsCount } from '@/hooks/use-events-count';
+import { useQueryPagination } from '@/hooks/use-query-pagination';
 
 export default function EventsTable() {
-  const { data: events, isLoading, error } = useEvents();
+  const { data: eventsCount } = useEventsCount();
+  
+  const pagination = useQueryPagination({ totalItems: eventsCount });
+
+  const {
+    data: events,
+    isLoading,
+    isFetching,
+    error,
+  } = useEvents({
+    page: pagination.page,
+    pageSize: pagination.pageSize,
+  });
   
   //TODO
   const transformedEvents = events?.map((event: Event) => ({
@@ -17,8 +31,8 @@ export default function EventsTable() {
     date: event.timestamp.toLocaleString(), // convert Date to string
   }));
 
-  const sortedTransformedEvents = transformedEvents?.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-
+  // Already did it at api level
+  // const sortedTransformedEvents = transformedEvents?.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   
   if(isLoading){
     return (
@@ -33,7 +47,9 @@ export default function EventsTable() {
 
   return (
     <>
-      {sortedTransformedEvents && <DataTable data={sortedTransformedEvents} columns={columns}/>}
+      {transformedEvents && (
+        <ApiDataTable data={transformedEvents} columns={columns} {...pagination} isLoading={isFetching} />
+      )}
     </>
-  )
+  );
 }

--- a/apps/webapp/src/hooks/use-events-count.tsx
+++ b/apps/webapp/src/hooks/use-events-count.tsx
@@ -1,0 +1,20 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import config from '@/utils/config';
+
+const fetchEventsCount = async (): Promise<number> => {
+  const response = await fetch(`${config.API_URL}/events/count`);
+
+  if (!response.ok) {
+    throw new Error('Network response was not ok');
+  }
+
+  return response.json();
+};
+
+export const useEventsCount = () => {
+  return useQuery({
+    queryKey: ['events count'],
+    queryFn: fetchEventsCount,
+    placeholderData: keepPreviousData,
+  });
+};

--- a/apps/webapp/src/hooks/use-query-pagination.tsx
+++ b/apps/webapp/src/hooks/use-query-pagination.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from 'react';
+import { useQueryParam } from 'use-query-params';
+
+import { NumberParamWithDefault } from '@/lib/utils';
+
+function getTotalPages(totalItems: number, pageSize: number) {
+  return Math.ceil(totalItems / pageSize);
+}
+
+interface UseQueryPaginationProps {
+  totalItems?: number;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+export const useQueryPagination = ({ totalItems = 0 }: UseQueryPaginationProps = {}) => {
+  const [page, setPage] = useQueryParam<number>('page', NumberParamWithDefault(DEFAULT_PAGE));
+  const [pageSize, setPageSize] = useQueryParam<number>('pageSize', NumberParamWithDefault(DEFAULT_PAGE_SIZE));
+
+  const totalPages = useMemo(() => {
+    return getTotalPages(totalItems, pageSize);
+  }, [totalItems, pageSize]);
+
+  const nextEnabled = useMemo(() => page < totalPages, [page, totalPages]);
+  const previousEnabled = useMemo(() => page > 1, [page]);
+
+  const setNextPage = useCallback(() => {
+    if (!nextEnabled) return;
+    setPage((page) => page + 1);
+  }, [nextEnabled, setPage]);
+
+  const setPreviousPage = useCallback(() => {
+    if (!previousEnabled) return;
+    setPage((page) => page - 1);
+  }, [previousEnabled, setPage]);
+
+  const resetPage = useCallback(() => {
+    setPage(DEFAULT_PAGE);
+  }, [setPage]);
+
+  const handlePageSizeChange = useCallback(
+    (newPageSize: number) => {
+      setPageSize(newPageSize);
+      setPage(DEFAULT_PAGE);
+    },
+    [setPageSize, setPage]
+  );
+
+  return {
+    page,
+    setPage,
+    resetPage,
+    pageSize,
+    setPageSize: handlePageSizeChange,
+    totalItems,
+    totalPages: totalPages === 0 ? 1 : totalPages,
+    nextEnabled,
+    previousEnabled,
+    setNextPage,
+    setPreviousPage,
+  };
+};
+export type UseQueryPaginationReturn = ReturnType<typeof useQueryPagination>;
+

--- a/apps/webapp/src/hooks/useEvents.tsx
+++ b/apps/webapp/src/hooks/useEvents.tsx
@@ -1,19 +1,27 @@
+import { PaginationParams } from '@/types';
 import config from '@/utils/config';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { events as Event } from 'api';
 
-const fetchEvents = async (): Promise<Event[]> => {
-  const response = await fetch(`${config.API_URL}/events`);
+const fetchEvents = async (params: PaginationParams): Promise<Event[]> => {
+  const searchParams = new URLSearchParams({
+    page: params.page.toString(),
+    pageSize: params.pageSize.toString(),
+  });
+
+  const response = await fetch(`${config.API_URL}/events?${searchParams.toString()}`);
+
   if (!response.ok) {
     throw new Error('Network response was not ok');
   }
   return response.json();
-}
+};
 
-const useEvents = () => {
+const useEvents = (params: PaginationParams) => {
   return useQuery({
-    queryKey: ['events'], 
-    queryFn: fetchEvents
+    queryKey: ['events', { page: params.page, pageSize: params.pageSize }],
+    queryFn: () => fetchEvents(params),
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
- 
+import { NumberParam, withDefault } from 'use-query-params';
+
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function NumberParamWithDefault(num: number) {
+  return withDefault(NumberParam, num);
 }

--- a/apps/webapp/src/types/index.ts
+++ b/apps/webapp/src/types/index.ts
@@ -2,3 +2,8 @@ export interface HookBaseReturn {
     isLoading: boolean;
     error: Error | null;
 }
+
+export interface PaginationParams {
+    page: number;
+    pageSize: number;
+}

--- a/packages/api/src/@core/events/events.controller.ts
+++ b/packages/api/src/@core/events/events.controller.ts
@@ -1,8 +1,15 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { EventsService } from './events.service';
 import { LoggerService } from '@@core/logger/logger.service';
-import { PrismaService } from '@@core/prisma/prisma.service';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { PaginationDto } from '@@core/utils/dtos/pagination.dto';
+
 @ApiTags('events')
 @Controller('events')
 export class EventsController {
@@ -15,8 +22,26 @@ export class EventsController {
 
   @ApiOperation({ operationId: 'getEvents', summary: 'Retrieve Events' })
   @ApiResponse({ status: 200 })
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  )
   @Get()
-  async getEvents() {
-    return await this.eventsService.findEvents();
+  async getEvents(@Query() dto: PaginationDto) {
+    return await this.eventsService.findEvents(dto);
+  }
+
+  @ApiOperation({
+    operationId: 'getEventsCount',
+    summary: 'Retrieve Events Count',
+  })
+  @Get('count')
+  async getEventsCount() {
+    return await this.eventsService.getEventsCount();
   }
 }

--- a/packages/api/src/@core/events/events.service.ts
+++ b/packages/api/src/@core/events/events.service.ts
@@ -1,5 +1,6 @@
 import { LoggerService } from '@@core/logger/logger.service';
 import { PrismaService } from '@@core/prisma/prisma.service';
+import { PaginationDto } from '@@core/utils/dtos/pagination.dto';
 import { handleServiceError } from '@@core/utils/errors';
 import { Injectable } from '@nestjs/common';
 
@@ -8,9 +9,21 @@ export class EventsService {
   constructor(private prisma: PrismaService, private logger: LoggerService) {
     this.logger.setContext(EventsService.name);
   }
-  async findEvents() {
+  async findEvents(dto: PaginationDto) {
     try {
-      return await this.prisma.events.findMany();
+      return await this.prisma.events.findMany({
+        orderBy: { timestamp: 'desc' },
+        skip: (dto.page - 1) * dto.pageSize,
+        take: dto.pageSize,
+      });
+    } catch (error) {
+      handleServiceError(error, this.logger);
+    }
+  }
+
+  async getEventsCount() {
+    try {
+      return await this.prisma.events.count();
     } catch (error) {
       handleServiceError(error, this.logger);
     }

--- a/packages/api/src/@core/utils/dtos/pagination.dto.ts
+++ b/packages/api/src/@core/utils/dtos/pagination.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsPositive, IsOptional } from 'class-validator';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+export class PaginationDto {
+  @IsNumber()
+  @IsPositive()
+  @IsOptional()
+  @ApiPropertyOptional()
+  page: number = DEFAULT_PAGE;
+
+  @IsNumber()
+  @IsPositive()
+  @IsOptional()
+  @ApiPropertyOptional()
+  pageSize: number = DEFAULT_PAGE_SIZE;
+}

--- a/packages/api/swagger/swagger-spec.json
+++ b/packages/api/swagger/swagger-spec.json
@@ -555,10 +555,53 @@
       "get": {
         "operationId": "getEvents",
         "summary": "Retrieve Events",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "pageSize",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "default": 10,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": ""
+          }
+        },
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/events/count": {
+      "get": {
+        "operationId": "getEventsCount",
+        "summary": "Retrieve Events Count",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
           }
         },
         "tags": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.1)
+      use-query-params:
+        specifier: ^2.2.1
+        version: 2.2.1(react-dom@18.2.0)(react-router-dom@6.22.0)(react@18.2.0)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -11345,6 +11348,10 @@ packages:
       randombytes: 2.1.0
     dev: true
 
+  /serialize-query-params@2.0.2:
+    resolution: {integrity: sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==}
+    dev: false
+
   /serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
@@ -12562,6 +12569,25 @@ packages:
       '@types/react': 18.2.55
       react: 18.2.0
       tslib: 2.6.2
+    dev: false
+
+  /use-query-params@2.2.1(react-dom@18.2.0)(react-router-dom@6.22.0)(react@18.2.0):
+    resolution: {integrity: sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==}
+    peerDependencies:
+      '@reach/router': ^1.2.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-router-dom: '>=5'
+    peerDependenciesMeta:
+      '@reach/router':
+        optional: true
+      react-router-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router-dom: 6.22.0(react-dom@18.2.0)(react@18.2.0)
+      serialize-query-params: 2.0.2
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.55)(react@18.2.0):


### PR DESCRIPTION
I added pagination for the events API endpoint and also the events table in the front end.
I didn't want to add pagination for other endpoints like `connections` and `API keys`.
For now, I didn't want to make the changes in the `data-table` because it was common among a lot of pages

## Results
![image](https://github.com/panoratech/Panora/assets/67981832/38232635-5291-4c4a-b4b9-1d4fcd76a21f)

## Endpoints
Created a new endpoint for events count
![image](https://github.com/freelance-collab/Panora/assets/62221802/bbffdc5d-2fe2-45ab-89d1-8ef9471eb7a3)

# Webapp
## Results
URL
![image](https://github.com/freelance-collab/Panora/assets/62221802/6a918142-0c0f-465d-ac1a-9b5af002e754)

Changed page or page size loading effect.
![image](https://github.com/freelance-collab/Panora/assets/62221802/15923858-3a6c-4ab5-94fa-14ae6603d9c2)

Added new package [use-query-params](https://www.npmjs.com/package/use-query-params) to make consistent client-side pagination based on search parameters.

Created a new `useQueryPagination` utility hook to handle pagination in the app.

Modified the `useEvents` hook to match with pagination strategy
![image](https://github.com/freelance-collab/Panora/assets/62221802/4f09aa87-227e-4f01-a5d9-a52a63dd77e9)

Created a New `ApiDataTable` component which is similar to the `Data-Table` component but with a new pagination configuration.