### PR TITLE
Fix throwing error when an error is thrown in the backend.

### DIFF
--- a/packages/api/src/@core/utils/errors.ts
+++ b/packages/api/src/@core/utils/errors.ts
@@ -79,6 +79,15 @@ export function handleServiceError(
   } else {
     logger.error('An unknown error occurred...', errorMessage);
   }
+
+  if (error instanceof HttpException) {
+    throw error;
+  }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    throw new HttpException(errorMessage, statusCode);
+  }
+
   return {
     data: null,
     error: errorMessage,


### PR DESCRIPTION
- When an error occurs in the backend, the server responds with 200 and doesn't throw/show an error. This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling logic to provide more specific exceptions based on the type of error encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->