### PR TITLE
Implemented functionality to reset configuration upon closure of LinkedUser dialog.

### DIFF
--- a/apps/webapp/src/components/configuration/components/AddLinkedAccount.tsx
+++ b/apps/webapp/src/components/configuration/components/AddLinkedAccount.tsx
@@ -63,6 +63,7 @@ const AddLinkedAccount = () => {
 
   const handleOpenChange = (open: boolean) => {
     setShowNewLinkedUserDialog(prevState => ({ ...prevState, open }));
+    form.reset()
   };
 
   const posthog = usePostHog()


### PR DESCRIPTION
- Resetting the form of the linked user on the configuration page upon dialog closure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where the form in the `Add Linked Account` component did not reset after submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->