### PR TITLE
Fix Sync service instances

### DIFF
--- a/packages/api/src/@core/sync/sync.module.ts
+++ b/packages/api/src/@core/sync/sync.module.ts
@@ -3,22 +3,6 @@ import { CoreSyncService } from './sync.service';
 import { SyncController } from './sync.controller';
 import { LoggerService } from '../logger/logger.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { SyncService as CrmCompanySyncService } from '@crm/company/sync/sync.service';
-import { SyncService as CrmContactSyncService } from '@crm/contact/sync/sync.service';
-import { SyncService as CrmDealSyncService } from '@crm/deal/sync/sync.service';
-import { SyncService as CrmEngagementSyncService } from '@crm/engagement/sync/sync.service';
-import { SyncService as CrmNoteSyncService } from '@crm/note/sync/sync.service';
-import { SyncService as CrmStageSyncService } from '@crm/stage/sync/sync.service';
-import { SyncService as CrmTaskSyncService } from '@crm/task/sync/sync.service';
-import { SyncService as CrmUserSyncService } from '@crm/user/sync/sync.service';
-import { SyncService as TicketingAccountSyncService } from '@ticketing/account/sync/sync.service';
-import { SyncService as TicketingCollectionSyncService } from '@ticketing/collection/sync/sync.service';
-import { SyncService as TicketingCommentSyncService } from '@ticketing/comment/sync/sync.service';
-import { SyncService as TicketingContactSyncService } from '@ticketing/contact/sync/sync.service';
-import { SyncService as TicketingTagSyncService } from '@ticketing/tag/sync/sync.service';
-import { SyncService as TicketingTeamSyncService } from '@ticketing/team/sync/sync.service';
-import { SyncService as TicketingTicketSyncService } from '@ticketing/ticket/sync/sync.service';
-import { SyncService as TicketingUserSyncService } from '@ticketing/user/sync/sync.service';
 import { BullModule } from '@nestjs/bull';
 import { CompanyModule } from '@crm/company/company.module';
 import { ContactModule } from '@crm/contact/contact.module';
@@ -64,23 +48,7 @@ import { UserModule as TUserModule } from '@ticketing/user/user.module';
     CoreSyncService,
     LoggerService,
     PrismaService,
-    CrmCompanySyncService,
-    CrmContactSyncService,
-    CrmDealSyncService,
-    CrmEngagementSyncService,
-    CrmNoteSyncService,
-    CrmStageSyncService,
-    CrmTaskSyncService,
-    CrmUserSyncService,
-    TicketingAccountSyncService,
-    TicketingCollectionSyncService,
-    TicketingCommentSyncService,
-    TicketingContactSyncService,
-    TicketingTagSyncService,
-    TicketingTeamSyncService,
-    TicketingTicketSyncService,
-    TicketingUserSyncService,
   ],
   controllers: [SyncController],
 })
-export class SyncModule {}
+export class SyncModule { }


### PR DESCRIPTION
- The sync service instances are created twice as we import each object module and provide it as a provider in [Sync.module.ts](packages/api/src/@core/sync/sync.module.ts).