### PR TITLE
Fix unification and mapping registries

### DIFF
--- a/packages/api/src/@core/core.module.ts
+++ b/packages/api/src/@core/core.module.ts
@@ -51,16 +51,16 @@ import { CoreUnification } from './utils/services/core.service';
     ConnectionsStrategiesModule,
     SyncModule,
     ProjectConnectorsModule,
-    MappersRegistry,
-    UnificationRegistry,
+    // MappersRegistry,
+    // UnificationRegistry,
     CoreUnification,
   ],
   providers: [
     EncryptionService,
     LoggerService,
-    MappersRegistry,
-    UnificationRegistry,
+    // MappersRegistry,
+    // UnificationRegistry,
     CoreUnification,
   ],
 })
-export class CoreModule {}
+export class CoreModule { }

--- a/packages/api/src/@core/utils/registry/registries.module.ts
+++ b/packages/api/src/@core/utils/registry/registries.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { MappersRegistry } from './mappings.registry';
+import { UnificationRegistry } from './unification.registry';
+
+
+@Global()
+@Module({
+    providers: [MappersRegistry, UnificationRegistry],
+    exports: [MappersRegistry, UnificationRegistry],
+})
+export class RegistriesModule { }

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -19,10 +19,11 @@ import { BullModule } from '@nestjs/bull';
 import { TicketingModule } from '@ticketing/ticketing.module';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from '@@core/prisma/prisma.module';
-
+import { RegistriesModule } from '@@core/utils/registry/registries.module';
 @Module({
   imports: [
     PrismaModule,
+    RegistriesModule,
     CoreModule,
     HrisModule,
     MarketingAutomationModule,
@@ -40,14 +41,14 @@ import { PrismaModule } from '@@core/prisma/prisma.module';
     ConfigModule.forRoot({ isGlobal: true }),
     ...(process.env.DISTRIBUTION === 'managed'
       ? [
-          SentryModule.forRoot({
-            dsn: process.env.SENTRY_DSN,
-            debug: true,
-            environment: `${process.env.ENV}-${process.env.DISTRIBUTION}`,
-            release: `${process.env.DISTRIBUTION}`,
-            logLevels: ['debug'],
-          }),
-        ]
+        SentryModule.forRoot({
+          dsn: process.env.SENTRY_DSN,
+          debug: true,
+          environment: `${process.env.ENV}-${process.env.DISTRIBUTION}`,
+          release: `${process.env.DISTRIBUTION}`,
+          logLevels: ['debug'],
+        }),
+      ]
       : []),
     ScheduleModule.forRoot(),
     LoggerModule.forRoot({
@@ -61,18 +62,18 @@ import { PrismaModule } from '@@core/prisma/prisma.module';
         transport:
           process.env.AXIOM_AGENT_STATUS === 'ENABLED'
             ? {
-                target: '@axiomhq/pino',
-                options: {
-                  dataset: process.env.AXIOM_DATASET,
-                  token: process.env.AXIOM_TOKEN,
-                },
-              }
-            : {
-                target: 'pino-pretty',
-                options: {
-                  singleLine: true,
-                },
+              target: '@axiomhq/pino',
+              options: {
+                dataset: process.env.AXIOM_DATASET,
+                token: process.env.AXIOM_TOKEN,
               },
+            }
+            : {
+              target: 'pino-pretty',
+              options: {
+                singleLine: true,
+              },
+            },
       },
     }),
     BullModule.forRoot({
@@ -111,4 +112,4 @@ import { PrismaModule } from '@@core/prisma/prisma.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule { }

--- a/packages/api/src/crm/company/company.module.ts
+++ b/packages/api/src/crm/company/company.module.ts
@@ -20,6 +20,14 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { AttioCompanyMapper } from './services/attio/mappers';
+import { CloseCompanyMapper } from './services/close/mappers';
+import { HubspotCompanyMapper } from './services/hubspot/mappers';
+import { PipedriveCompanyMapper } from './services/pipedrive/mappers';
+import { ZendeskCompanyMapper } from './services/zendesk/mappers';
+import { ZohoCompanyMapper } from './services/zoho/mappers';
+
+
 
 @Module({
   imports: [
@@ -40,8 +48,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +58,14 @@ import { Utils } from '@crm/@lib/@utils';
     HubspotService,
     AttioService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    AttioCompanyMapper,
+    CloseCompanyMapper,
+    HubspotCompanyMapper,
+    PipedriveCompanyMapper,
+    ZendeskCompanyMapper,
+    ZohoCompanyMapper
+
   ],
   exports: [
     SyncService,
@@ -59,4 +75,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class CompanyModule {}
+export class CompanyModule { }

--- a/packages/api/src/crm/contact/contact.module.ts
+++ b/packages/api/src/crm/contact/contact.module.ts
@@ -20,6 +20,12 @@ import { UnificationRegistry } from '@@core/utils/registry/unification.registry'
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
 import { ConnectionUtils } from '@@core/connections/@utils';
+import { AttioContactMapper } from './services/attio/mappers';
+import { CloseContactMapper } from './services/close/mappers';
+import { HubspotContactMapper } from './services/hubspot/mappers';
+import { PipedriveContactMapper } from './services/pipedrive/mappers';
+import { ZendeskContactMapper } from './services/zendesk/mappers';
+import { ZohoContactMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +47,8 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     EncryptionService,
     ServiceRegistry,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     ConnectionUtils,
     /* PROVIDERS SERVICES */
@@ -52,6 +58,13 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    AttioContactMapper,
+    CloseContactMapper,
+    HubspotContactMapper,
+    PipedriveContactMapper,
+    ZendeskContactMapper,
+    ZohoContactMapper
   ],
   exports: [
     SyncService,
@@ -61,4 +74,4 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     LoggerService,
   ],
 })
-export class ContactModule {}
+export class ContactModule { }

--- a/packages/api/src/crm/crm.module.ts
+++ b/packages/api/src/crm/crm.module.ts
@@ -8,7 +8,7 @@ import { TaskModule } from './task/task.module';
 import { UserModule } from './user/user.module';
 import { CompanyModule } from './company/company.module';
 import { CrmWebhookHandlerModule } from './@webhook/handler.module';
-
+import { CrmUnificationService } from './@lib/@unification';
 @Module({
   imports: [
     ContactModule,
@@ -21,7 +21,9 @@ import { CrmWebhookHandlerModule } from './@webhook/handler.module';
     UserModule,
     CrmWebhookHandlerModule,
   ],
-  providers: [],
+  providers: [
+    CrmUnificationService
+  ],
   exports: [
     ContactModule,
     DealModule,
@@ -34,4 +36,4 @@ import { CrmWebhookHandlerModule } from './@webhook/handler.module';
     CrmWebhookHandlerModule,
   ],
 })
-export class CrmModule {}
+export class CrmModule { }

--- a/packages/api/src/crm/deal/deal.module.ts
+++ b/packages/api/src/crm/deal/deal.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseDealMapper } from './services/close/mappers';
+import { HubspotDealMapper } from './services/hubspot/mappers';
+import { PipedriveDealMapper } from './services/pipedrive/mappers';
+import { ZendeskDealMapper } from './services/zendesk/mappers';
+import { ZohoDealMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskDealMapper,
+    ZohoDealMapper,
+    PipedriveDealMapper,
+    HubspotDealMapper,
+    CloseDealMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class DealModule {}
+export class DealModule { }

--- a/packages/api/src/crm/engagement/engagement.module.ts
+++ b/packages/api/src/crm/engagement/engagement.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseEngagementMapper } from './services/close/mappers';
+import { HubspotEngagementMapper } from './services/hubspot/mappers';
+import { PipedriveEngagementMapper } from './services/pipedrive/mappers';
+import { ZendeskEngagementMapper } from './services/zendesk/mappers';
+import { ZohoEngagementMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskEngagementMapper,
+    ZohoEngagementMapper,
+    PipedriveEngagementMapper,
+    HubspotEngagementMapper,
+    CloseEngagementMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class EngagementModule {}
+export class EngagementModule { }

--- a/packages/api/src/crm/engagement/services/zoho/mappers.ts
+++ b/packages/api/src/crm/engagement/services/zoho/mappers.ts
@@ -6,7 +6,8 @@ import {
 import { IEngagementMapper } from '@crm/engagement/types';
 import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { Injectable } from '@nestjs/common';
-import { Utils } from '@ticketing/@lib/@utils';
+import { Utils } from '@crm/@lib/@utils';
+
 
 @Injectable()
 export class ZohoEngagementMapper implements IEngagementMapper {

--- a/packages/api/src/crm/note/note.module.ts
+++ b/packages/api/src/crm/note/note.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseNoteMapper } from './services/close/mappers';
+import { HubspotNoteMapper } from './services/hubspot/mappers';
+import { PipedriveNoteMapper } from './services/pipedrive/mappers';
+import { ZendeskNoteMapper } from './services/zendesk/mappers';
+import { ZohoNoteMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskNoteMapper,
+    ZohoNoteMapper,
+    PipedriveNoteMapper,
+    HubspotNoteMapper,
+    CloseNoteMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class NoteModule {}
+export class NoteModule { }

--- a/packages/api/src/crm/stage/stage.module.ts
+++ b/packages/api/src/crm/stage/stage.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseStageMapper } from './services/close/mappers';
+import { HubspotStageMapper } from './services/hubspot/mappers';
+import { PipedriveStageMapper } from './services/pipedrive/mappers';
+import { ZendeskStageMapper } from './services/zendesk/mappers';
+import { ZohoStageMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskStageMapper,
+    ZohoStageMapper,
+    PipedriveStageMapper,
+    HubspotStageMapper,
+    CloseStageMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class StageModule {}
+export class StageModule { }

--- a/packages/api/src/crm/task/task.module.ts
+++ b/packages/api/src/crm/task/task.module.ts
@@ -19,6 +19,12 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseTaskMapper } from './services/close/mappers';
+import { HubspotTaskMapper } from './services/hubspot/mappers';
+import { PipedriveTaskMapper } from './services/pipedrive/mappers';
+import { ZendeskTaskMapper } from './services/zendesk/mappers';
+import { ZohoTaskMapper } from './services/zoho/mappers';
+
 
 @Module({
   imports: [
@@ -41,8 +47,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +56,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskTaskMapper,
+    ZohoTaskMapper,
+    PipedriveTaskMapper,
+    HubspotTaskMapper,
+    CloseTaskMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +71,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class TaskModule {}
+export class TaskModule { }

--- a/packages/api/src/crm/user/user.module.ts
+++ b/packages/api/src/crm/user/user.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@crm/@lib/@utils';
+import { CloseUserMapper } from './services/close/mappers';
+import { HubspotUserMapper } from './services/hubspot/mappers';
+import { PipedriveUserMapper } from './services/pipedrive/mappers';
+import { ZendeskUserMapper } from './services/zendesk/mappers';
+import { ZohoUserMapper } from './services/zoho/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { Utils } from '@crm/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { Utils } from '@crm/@lib/@utils';
     PipedriveService,
     HubspotService,
     CloseService,
+    /* PROVIDERS MAPPERS */
+    ZendeskUserMapper,
+    ZohoUserMapper,
+    PipedriveUserMapper,
+    HubspotUserMapper,
+    CloseUserMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { Utils } from '@crm/@lib/@utils';
     LoggerService,
   ],
 })
-export class UserModule {}
+export class UserModule { }

--- a/packages/api/src/ticketing/account/account.module.ts
+++ b/packages/api/src/ticketing/account/account.module.ts
@@ -15,7 +15,9 @@ import { FrontService } from './services/front';
 import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
-
+import { FrontAccountMapper } from './services/front/mappers';
+import { ZendeskAccountMapper } from './services/zendesk/mappers';
+import { Utils } from '@ticketing/@lib/@utils';
 @Module({
   imports: [
     BullModule.registerQueue(
@@ -37,11 +39,15 @@ import { CoreUnification } from '@@core/utils/services/core.service';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    Utils,
+    // UnificationRegistry,
+    // MappersRegistry,
     /* PROVIDERS SERVICES */
     ZendeskService,
     FrontService,
+    /* PROVIDERS MAPPERS */
+    ZendeskAccountMapper,
+    FrontAccountMapper,
   ],
   exports: [
     SyncService,
@@ -51,4 +57,4 @@ import { CoreUnification } from '@@core/utils/services/core.service';
     LoggerService,
   ],
 })
-export class AccountModule {}
+export class AccountModule { }

--- a/packages/api/src/ticketing/attachment/attachment.module.ts
+++ b/packages/api/src/ticketing/attachment/attachment.module.ts
@@ -12,7 +12,11 @@ import { ConnectionUtils } from '@@core/connections/@utils';
 import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
-
+import { FrontAttachmentMapper } from './services/front/mappers';
+import { GorgiasAttachmentMapper } from './services/gorgias/mappers';
+import { JiraAttachmentMapper } from './services/jira/mappers';
+import { ZendeskAttachmentMapper } from './services/zendesk/mappers';
+import { Utils } from '@ticketing/@lib/@utils';
 @Module({
   imports: [
     BullModule.registerQueue(
@@ -33,9 +37,18 @@ import { CoreUnification } from '@@core/utils/services/core.service';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    Utils,
+    // UnificationRegistry,
+    // MappersRegistry,
     /* PROVIDERS SERVICES */
+
+    /* PROVIDERS Mappers */
+    FrontAttachmentMapper,
+    GorgiasAttachmentMapper,
+    JiraAttachmentMapper,
+    ZendeskAttachmentMapper
+
+
   ],
 })
-export class AttachmentModule {}
+export class AttachmentModule { }

--- a/packages/api/src/ticketing/collection/collection.module.ts
+++ b/packages/api/src/ticketing/collection/collection.module.ts
@@ -15,6 +15,9 @@ import { JiraService } from './services/jira';
 import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
+import { GitlabCollectionMapper } from './services/gitlab/mappers';
+import { JiraCollectionMapper } from './services/jira/mappers';
+import { Utils } from '@ticketing/@lib/@utils';
 
 @Module({
   imports: [
@@ -37,11 +40,15 @@ import { CoreUnification } from '@@core/utils/services/core.service';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    Utils,
+    // UnificationRegistry,
+    // MappersRegistry,
     /* PROVIDERS SERVICES */
     JiraService,
     GitlabService,
+    /* PROVIDERS MAPPERS */
+    JiraCollectionMapper,
+    GitlabCollectionMapper,
   ],
   exports: [
     SyncService,
@@ -51,4 +58,4 @@ import { CoreUnification } from '@@core/utils/services/core.service';
     LoggerService,
   ],
 })
-export class CollectionModule {}
+export class CollectionModule { }

--- a/packages/api/src/ticketing/comment/comment.module.ts
+++ b/packages/api/src/ticketing/comment/comment.module.ts
@@ -19,6 +19,11 @@ import { UnificationRegistry } from '@@core/utils/registry/unification.registry'
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@ticketing/@lib/@utils';
 import { ConnectionUtils } from '@@core/connections/@utils';
+import { FrontCommentMapper } from './services/front/mappers';
+import { GitlabCommentMapper } from './services/gitlab/mappers';
+import { GorgiasCommentMapper } from './services/gorgias/mappers';
+import { JiraCommentMapper } from './services/jira/mappers';
+import { ZendeskCommentMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -41,8 +46,8 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -50,6 +55,12 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     JiraService,
     GorgiasService,
     GitlabService,
+    /* PROVIDERS MAPPERS */
+    ZendeskCommentMapper,
+    FrontCommentMapper,
+    JiraCommentMapper,
+    GorgiasCommentMapper,
+    GitlabCommentMapper,
   ],
   exports: [
     SyncService,
@@ -59,4 +70,4 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     LoggerService,
   ],
 })
-export class CommentModule {}
+export class CommentModule { }

--- a/packages/api/src/ticketing/contact/contact.module.ts
+++ b/packages/api/src/ticketing/contact/contact.module.ts
@@ -17,6 +17,9 @@ import { UnificationRegistry } from '@@core/utils/registry/unification.registry'
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@ticketing/@lib/@utils';
 import { ConnectionUtils } from '@@core/connections/@utils';
+import { FrontContactMapper } from './services/front/mappers';
+import { GorgiasContactMapper } from './services/gorgias/mappers';
+import { ZendeskContactMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -39,13 +42,17 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
     FrontService,
     GorgiasService,
+    /* PROVIDERS MAPPERS */
+    ZendeskContactMapper,
+    FrontContactMapper,
+    GorgiasContactMapper,
   ],
   exports: [
     SyncService,
@@ -55,4 +62,4 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     LoggerService,
   ],
 })
-export class ContactModule {}
+export class ContactModule { }

--- a/packages/api/src/ticketing/tag/tag.module.ts
+++ b/packages/api/src/ticketing/tag/tag.module.ts
@@ -18,6 +18,10 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@ticketing/@lib/@utils';
+import { FrontTagMapper } from './services/front/mappers';
+import { GorgiasTagMapper } from './services/gorgias/mappers';
+import { JiraTagMapper } from './services/jira/mappers';
+import { ZendeskTagMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -40,14 +44,19 @@ import { Utils } from '@ticketing/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
     FrontService,
     JiraService,
     GorgiasService,
+    /* PROVIDERS MAPPERS */
+    ZendeskTagMapper,
+    FrontTagMapper,
+    JiraTagMapper,
+    GorgiasTagMapper,
   ],
   exports: [
     SyncService,
@@ -57,4 +66,4 @@ import { Utils } from '@ticketing/@lib/@utils';
     LoggerService,
   ],
 })
-export class TagModule {}
+export class TagModule { }

--- a/packages/api/src/ticketing/team/team.module.ts
+++ b/packages/api/src/ticketing/team/team.module.ts
@@ -18,6 +18,10 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@ticketing/@lib/@utils';
+import { FrontTeamMapper } from './services/front/mappers';
+import { GorgiasTeamMapper } from './services/gorgias/mappers';
+import { JiraTeamMapper } from './services/jira/mappers';
+import { ZendeskTeamMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -40,14 +44,19 @@ import { Utils } from '@ticketing/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
     FrontService,
     JiraService,
     GorgiasService,
+    /* PROVIDERS MAPPERS */
+    ZendeskTeamMapper,
+    FrontTeamMapper,
+    JiraTeamMapper,
+    GorgiasTeamMapper,
   ],
   exports: [
     SyncService,
@@ -57,4 +66,4 @@ import { Utils } from '@ticketing/@lib/@utils';
     LoggerService,
   ],
 })
-export class TeamModule {}
+export class TeamModule { }

--- a/packages/api/src/ticketing/ticket/ticket.module.ts
+++ b/packages/api/src/ticketing/ticket/ticket.module.ts
@@ -21,6 +21,13 @@ import { UnificationRegistry } from '@@core/utils/registry/unification.registry'
 import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { Utils } from '@ticketing/@lib/@utils';
 import { ConnectionUtils } from '@@core/connections/@utils';
+import { FrontTicketMapper } from './services/front/mappers';
+import { GithubTicketMapper } from './services/github/mappers';
+import { GitlabTicketMapper } from './services/gitlab/mappers';
+import { GorgiasTicketMapper } from './services/gorgias/mappers';
+import { HubspotTicketMapper } from './services/hubspot/mappers';
+import { JiraTicketMapper } from './services/jira/mappers';
+import { ZendeskTicketMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -42,8 +49,8 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -53,6 +60,14 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     JiraService,
     GorgiasService,
     GitlabService,
+    /* PROVIDERS MAPPERS */
+    ZendeskTicketMapper,
+    HubspotTicketMapper,
+    FrontTicketMapper,
+    GithubTicketMapper,
+    JiraTicketMapper,
+    GorgiasTicketMapper,
+    GitlabTicketMapper,
   ],
   exports: [
     SyncService,
@@ -62,4 +77,4 @@ import { ConnectionUtils } from '@@core/connections/@utils';
     LoggerService,
   ],
 })
-export class TicketModule {}
+export class TicketModule { }

--- a/packages/api/src/ticketing/ticketing.module.ts
+++ b/packages/api/src/ticketing/ticketing.module.ts
@@ -9,6 +9,7 @@ import { TagModule } from './tag/tag.module';
 import { TeamModule } from './team/team.module';
 import { CollectionModule } from './collection/collection.module';
 import { TicketingWebhookHandlerModule } from './@webhook/handler.module';
+import { TicketingUnificationService } from './@lib/@unification';
 
 @Module({
   imports: [
@@ -23,7 +24,9 @@ import { TicketingWebhookHandlerModule } from './@webhook/handler.module';
     CollectionModule,
     TicketingWebhookHandlerModule,
   ],
-  providers: [],
+  providers: [
+    TicketingUnificationService
+  ],
   controllers: [],
   exports: [
     TicketModule,
@@ -38,4 +41,4 @@ import { TicketingWebhookHandlerModule } from './@webhook/handler.module';
     TicketingWebhookHandlerModule,
   ],
 })
-export class TicketingModule {}
+export class TicketingModule { }

--- a/packages/api/src/ticketing/user/user.module.ts
+++ b/packages/api/src/ticketing/user/user.module.ts
@@ -19,6 +19,11 @@ import { MappersRegistry } from '@@core/utils/registry/mappings.registry';
 import { UnificationRegistry } from '@@core/utils/registry/unification.registry';
 import { CoreUnification } from '@@core/utils/services/core.service';
 import { Utils } from '@ticketing/@lib/@utils';
+import { FrontUserMapper } from './services/front/mappers';
+import { GitlabUserMapper } from './services/gitlab/mappers';
+import { GorgiasUserMapper } from './services/gorgias/mappers';
+import { JiraUserMapper } from './services/jira/mappers';
+import { ZendeskUserMapper } from './services/zendesk/mappers';
 
 @Module({
   imports: [
@@ -40,8 +45,8 @@ import { Utils } from '@ticketing/@lib/@utils';
     ServiceRegistry,
     ConnectionUtils,
     CoreUnification,
-    UnificationRegistry,
-    MappersRegistry,
+    // UnificationRegistry,
+    // MappersRegistry,
     Utils,
     /* PROVIDERS SERVICES */
     ZendeskService,
@@ -49,6 +54,12 @@ import { Utils } from '@ticketing/@lib/@utils';
     JiraService,
     GorgiasService,
     GitlabService,
+    /* PROVIDERS MAPPERS */
+    ZendeskUserMapper,
+    FrontUserMapper,
+    JiraUserMapper,
+    GorgiasUserMapper,
+    GitlabUserMapper,
   ],
   exports: [
     SyncService,
@@ -58,4 +69,4 @@ import { Utils } from '@ticketing/@lib/@utils';
     LoggerService,
   ],
 })
-export class UserModule {}
+export class UserModule { }


### PR DESCRIPTION
**Issues that are being resolved:**
- Each object is creating mapping and unification registry instances. As a result, we are not getting any service instances for unification and mapping methods.
- We are not adding the connectors' mapper to the Mapper registry or the vertical's unifier instance to the Unify registry.

@naelob, it would be better to incorporate these changes into the active PR you are working on.