### PR TITLE
Fix critical bugs

### DIFF
--- a/packages/api/src/ats/activity/services/registry.service.ts
+++ b/packages/api/src/ats/activity/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IActivityService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/activity/sync/sync.service.ts
+++ b/packages/api/src/ats/activity/sync/sync.service.ts
@@ -56,12 +56,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing activities....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -92,7 +92,7 @@ export class SyncService implements OnModuleInit, IBaseSync {
                     const candidates =
                       await this.prisma.ats_candidates.findMany({
                         where: {
-                          id_connection: connection.id_connection,
+                          id_connection: connection?.id_connection,
                         },
                       });
                     for (const candidate of candidates) {
@@ -124,7 +124,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, id_candidate } = data;
       const service: IActivityService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: activity} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsActivityOutput,

--- a/packages/api/src/ats/application/services/registry.service.ts
+++ b/packages/api/src/ats/application/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IApplicationService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/application/sync/sync.service.ts
+++ b/packages/api/src/ats/application/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing applications...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -104,7 +104,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IApplicationService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: application} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsApplicationOutput,

--- a/packages/api/src/ats/attachment/services/registry.service.ts
+++ b/packages/api/src/ats/attachment/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IAttachmentService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/candidate/services/registry.service.ts
+++ b/packages/api/src/ats/candidate/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ICandidateService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/candidate/sync/sync.service.ts
+++ b/packages/api/src/ats/candidate/sync/sync.service.ts
@@ -57,12 +57,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing candidates...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -108,7 +108,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ICandidateService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: candidate} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsCandidateOutput,

--- a/packages/api/src/ats/department/services/registry.service.ts
+++ b/packages/api/src/ats/department/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IDepartmentService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/department/sync/sync.service.ts
+++ b/packages/api/src/ats/department/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing departments...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -104,7 +104,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IDepartmentService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: department} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsDepartmentOutput,

--- a/packages/api/src/ats/eeocs/services/registry.service.ts
+++ b/packages/api/src/ats/eeocs/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IEeocsService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/eeocs/sync/sync.service.ts
+++ b/packages/api/src/ats/eeocs/sync/sync.service.ts
@@ -50,12 +50,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing EEOCs...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,7 +101,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IEeocsService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: eeocs} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsEeocsOutput,

--- a/packages/api/src/ats/interview/services/registry.service.ts
+++ b/packages/api/src/ats/interview/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IInterviewService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/interview/sync/sync.service.ts
+++ b/packages/api/src/ats/interview/sync/sync.service.ts
@@ -52,12 +52,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing interviews...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -103,7 +103,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IInterviewService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: interview} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsInterviewOutput,

--- a/packages/api/src/ats/job/services/registry.service.ts
+++ b/packages/api/src/ats/job/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IJobService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/job/sync/sync.service.ts
+++ b/packages/api/src/ats/job/sync/sync.service.ts
@@ -50,12 +50,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing jobs...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,7 +101,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IJobService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: job} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsJobOutput,

--- a/packages/api/src/ats/jobinterviewstage/services/registry.service.ts
+++ b/packages/api/src/ats/jobinterviewstage/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IJobInterviewStageService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/jobinterviewstage/sync/sync.service.ts
+++ b/packages/api/src/ats/jobinterviewstage/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing job interview stages...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -104,7 +104,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IJobInterviewStageService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: jobinterviewstage} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsJobinterviewstageOutput,

--- a/packages/api/src/ats/offer/services/registry.service.ts
+++ b/packages/api/src/ats/offer/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IOfferService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/offer/sync/sync.service.ts
+++ b/packages/api/src/ats/offer/sync/sync.service.ts
@@ -50,12 +50,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing offers...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,7 +101,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IOfferService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: offer} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsOfferOutput,

--- a/packages/api/src/ats/office/services/registry.service.ts
+++ b/packages/api/src/ats/office/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IOfficeService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/office/sync/sync.service.ts
+++ b/packages/api/src/ats/office/sync/sync.service.ts
@@ -50,12 +50,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing offices...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,7 +101,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IOfficeService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: office} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsOfficeOutput,

--- a/packages/api/src/ats/rejectreason/services/registry.service.ts
+++ b/packages/api/src/ats/rejectreason/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IRejectReasonService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/rejectreason/sync/sync.service.ts
+++ b/packages/api/src/ats/rejectreason/sync/sync.service.ts
@@ -52,12 +52,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing reject reasons...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -103,7 +103,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IRejectReasonService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: rejectreason} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsRejectreasonOutput,

--- a/packages/api/src/ats/scorecard/services/registry.service.ts
+++ b/packages/api/src/ats/scorecard/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IScoreCardService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/scorecard/sync/sync.service.ts
+++ b/packages/api/src/ats/scorecard/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing score cards...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -104,7 +104,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IScoreCardService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: scorecard} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsScorecardOutput,

--- a/packages/api/src/ats/tag/services/registry.service.ts
+++ b/packages/api/src/ats/tag/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ITagService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/tag/sync/sync.service.ts
+++ b/packages/api/src/ats/tag/sync/sync.service.ts
@@ -49,12 +49,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing tags...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -100,7 +100,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ITagService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: tag} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsTagOutput,

--- a/packages/api/src/ats/user/services/registry.service.ts
+++ b/packages/api/src/ats/user/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IUserService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ats/user/sync/sync.service.ts
+++ b/packages/api/src/ats/user/sync/sync.service.ts
@@ -50,12 +50,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log('Syncing users...');
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,7 +101,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IUserService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ats, commonObject: user} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedAtsUserOutput,

--- a/packages/api/src/crm/company/services/registry.service.ts
+++ b/packages/api/src/crm/company/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ICompanyService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/company/sync/sync.service.ts
+++ b/packages/api/src/crm/company/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing companies....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -107,7 +107,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ICompanyService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: company} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmCompanyOutput,

--- a/packages/api/src/crm/contact/services/registry.service.ts
+++ b/packages/api/src/crm/contact/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IContactService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/contact/sync/sync.service.ts
+++ b/packages/api/src/crm/contact/sync/sync.service.ts
@@ -58,12 +58,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
 
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -112,7 +112,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IContactService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: contact} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmContactOutput,

--- a/packages/api/src/crm/deal/services/registry.service.ts
+++ b/packages/api/src/crm/deal/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IDealService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/deal/sync/sync.service.ts
+++ b/packages/api/src/crm/deal/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing deals....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -102,7 +102,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IDealService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: deal} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmDealOutput,

--- a/packages/api/src/crm/engagement/services/registry.service.ts
+++ b/packages/api/src/crm/engagement/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IEngagementService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/engagement/sync/sync.service.ts
+++ b/packages/api/src/crm/engagement/sync/sync.service.ts
@@ -56,12 +56,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing engagements....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -114,7 +114,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, engagement_type } = data;
       const service: IEngagementService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: engagement} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmEngagementOutput,

--- a/packages/api/src/crm/note/services/registry.service.ts
+++ b/packages/api/src/crm/note/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): INoteService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/note/sync/sync.service.ts
+++ b/packages/api/src/crm/note/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing notes....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -107,7 +107,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: INoteService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: note} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmNoteOutput,

--- a/packages/api/src/crm/stage/services/registry.service.ts
+++ b/packages/api/src/crm/stage/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IStageService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/stage/sync/sync.service.ts
+++ b/packages/api/src/crm/stage/sync/sync.service.ts
@@ -51,12 +51,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing stages....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -90,7 +90,7 @@ export class SyncService implements OnModuleInit, IBaseSync {
                       //call the sync comments for every ticket of the linkedUser (a comment is tied to a ticket)
                       const deals = await this.prisma.crm_deals.findMany({
                         where: {
-                          id_connection: connection.id_connection,
+                          id_connection: connection?.id_connection,
                         },
                       });
                       for (const deal of deals) {
@@ -125,7 +125,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, deal_id } = data;
       const service: IStageService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: stage} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmStageOutput,

--- a/packages/api/src/crm/task/services/registry.service.ts
+++ b/packages/api/src/crm/task/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ITaskService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/task/sync/sync.service.ts
+++ b/packages/api/src/crm/task/sync/sync.service.ts
@@ -54,12 +54,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing tasks....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -108,7 +108,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ITaskService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: task} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmTaskOutput,

--- a/packages/api/src/crm/user/services/registry.service.ts
+++ b/packages/api/src/crm/user/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IUserService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/crm/user/sync/sync.service.ts
+++ b/packages/api/src/crm/user/sync/sync.service.ts
@@ -53,12 +53,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing users....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -107,7 +107,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: IUserService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:crm, commonObject: user} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedCrmUserOutput,

--- a/packages/api/src/ticketing/account/services/registry.service.ts
+++ b/packages/api/src/ticketing/account/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IAccountService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/account/sync/sync.service.ts
+++ b/packages/api/src/ticketing/account/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing accounts....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -100,6 +100,11 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, wh_real_time_trigger } = data;
       const service: IAccountService =
         this.serviceRegistry.getService(integrationId);
+
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: account} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingAccountOutput,

--- a/packages/api/src/ticketing/attachment/services/registry.service.ts
+++ b/packages/api/src/ticketing/attachment/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IAttachmentService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/collection/services/registry.service.ts
+++ b/packages/api/src/ticketing/collection/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ICollectionService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/collection/sync/sync.service.ts
+++ b/packages/api/src/ticketing/collection/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing collections....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -100,7 +100,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ICollectionService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: collection} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingCollectionOutput,

--- a/packages/api/src/ticketing/comment/services/registry.service.ts
+++ b/packages/api/src/ticketing/comment/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ICommentService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/comment/sync/sync.service.ts
+++ b/packages/api/src/ticketing/comment/sync/sync.service.ts
@@ -49,12 +49,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing comments....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -84,7 +84,7 @@ export class SyncService implements OnModuleInit, IBaseSync {
                     //call the sync comments for every ticket of the linkedUser (a comment is tied to a ticket)
                     const tickets = await this.prisma.tcg_tickets.findMany({
                       where: {
-                        id_connection: connection.id_connection,
+                        id_connection: connection?.id_connection,
                       },
                     });
                     for (const ticket of tickets) {
@@ -116,7 +116,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, id_ticket } = data;
       const service: ICommentService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: comment} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingCommentOutput,
@@ -163,8 +166,8 @@ export class SyncService implements OnModuleInit, IBaseSync {
           comment.creator_type === 'CONTACT' && comment.contact_id
             ? { id_tcg_contact: comment.contact_id }
             : comment.creator_type === 'USER' && comment.user_id
-            ? { id_tcg_user: comment.user_id }
-            : {};
+              ? { id_tcg_user: comment.user_id }
+              : {};
 
         const baseData: any = {
           id_tcg_ticket: id_ticket ?? null,

--- a/packages/api/src/ticketing/contact/services/registry.service.ts
+++ b/packages/api/src/ticketing/contact/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IContactService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/contact/sync/sync.service.ts
+++ b/packages/api/src/ticketing/contact/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing contacts....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -101,6 +101,11 @@ export class SyncService implements OnModuleInit, IBaseSync {
         data;
       const service: IContactService =
         this.serviceRegistry.getService(integrationId);
+
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: contact} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingContactOutput,

--- a/packages/api/src/ticketing/tag/services/registry.service.ts
+++ b/packages/api/src/ticketing/tag/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ITagService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/tag/sync/sync.service.ts
+++ b/packages/api/src/ticketing/tag/sync/sync.service.ts
@@ -55,12 +55,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing tags....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -90,7 +90,7 @@ export class SyncService implements OnModuleInit, IBaseSync {
                     //call the sync comments for every ticket of the linkedUser (a comment is tied to a ticket)
                     const tickets = await this.prisma.tcg_tickets.findMany({
                       where: {
-                        id_connection: connection.id_connection,
+                        id_connection: connection?.id_connection,
                       },
                     });
                     for (const ticket of tickets) {
@@ -122,7 +122,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, id_ticket } = data;
       const service: ITagService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: tag} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingTagOutput,

--- a/packages/api/src/ticketing/team/services/registry.service.ts
+++ b/packages/api/src/ticketing/team/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ITeamService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/team/sync/sync.service.ts
+++ b/packages/api/src/ticketing/team/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing teams....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -100,7 +100,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId } = param;
       const service: ITeamService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: team} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingTeamOutput,

--- a/packages/api/src/ticketing/ticket/services/registry.service.ts
+++ b/packages/api/src/ticketing/ticket/services/registry.service.ts
@@ -15,11 +15,11 @@ export class ServiceRegistry {
 
   getService(integrationId: string): ITicketService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new ReferenceError(
-        `Service not found for integration ID: ${integrationId}`,
-      );
-    }
+    // if (!service) {
+    //   throw new ReferenceError(
+    //     `Service not found for integration ID: ${integrationId}`,
+    //   );
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/ticket/sync/sync.service.ts
+++ b/packages/api/src/ticketing/ticket/sync/sync.service.ts
@@ -51,12 +51,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing tickets....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -103,6 +103,11 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, wh_real_time_trigger } = param;
       const service: ITicketService =
         this.serviceRegistry.getService(integrationId);
+
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: ticket} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingTicketOutput,

--- a/packages/api/src/ticketing/user/services/registry.service.ts
+++ b/packages/api/src/ticketing/user/services/registry.service.ts
@@ -15,9 +15,9 @@ export class ServiceRegistry {
 
   getService(integrationId: string): IUserService {
     const service = this.serviceMap.get(integrationId);
-    if (!service) {
-      throw new Error();
-    }
+    // if (!service) {
+    //   throw new Error();
+    // }
     return service;
   }
 }

--- a/packages/api/src/ticketing/user/sync/sync.service.ts
+++ b/packages/api/src/ticketing/user/sync/sync.service.ts
@@ -48,12 +48,12 @@ export class SyncService implements OnModuleInit, IBaseSync {
       this.logger.log(`Syncing users....`);
       const users = user_id
         ? [
-            await this.prisma.users.findUnique({
-              where: {
-                id_user: user_id,
-              },
-            }),
-          ]
+          await this.prisma.users.findUnique({
+            where: {
+              id_user: user_id,
+            },
+          }),
+        ]
         : await this.prisma.users.findMany();
       if (users && users.length > 0) {
         for (const user of users) {
@@ -100,7 +100,10 @@ export class SyncService implements OnModuleInit, IBaseSync {
       const { integrationId, linkedUserId, wh_real_time_trigger } = param;
       const service: IUserService =
         this.serviceRegistry.getService(integrationId);
-      if (!service) return;
+      if (!service) {
+        this.logger.log(`No service found in {vertical:ticketing, commonObject: user} for integration ID: ${integrationId}`);
+        return;
+      }
 
       await this.ingestService.syncForLinkedUser<
         UnifiedTicketingUserOutput,


### PR DESCRIPTION
**Bug Info**
- If the connector object is not available for a specific vertical, the service will not be available and throw an error which will propagate to parent try blocks and eventually stop kickstartSync. (It is happening inside sync.service.ts for every object)

**Solution (It covered Ticketing, CRM and ATS verticals)**
- Added an appropriate log message for unavailable services for objects and removed the error throw from registry.service.ts.