### PR TITLE
fix: add missing columns to connector_sets migration scripts

### DIFF
--- a/packages/api/scripts/init.sql
+++ b/packages/api/scripts/init.sql
@@ -545,6 +545,8 @@ CREATE TABLE connector_sets
  ecom_shopify     boolean NULL,
  ecom_amazon      boolean NULL,
  ecom_squarespace boolean NULL,
+ hris_gusto       boolean NULL,
+ ats_bamboohr     boolean NULL,
  CONSTRAINT PK_project_connector PRIMARY KEY ( id_connector_set )
 );
 

--- a/packages/api/scripts/seed.sql
+++ b/packages/api/scripts/seed.sql
@@ -2,9 +2,9 @@ INSERT INTO users (id_user, identification_strategy, email, password_hash, first
 ('0ce39030-2901-4c56-8db0-5e326182ec6b', 'b2c','local@panora.dev', '$2b$10$Y7Q8TWGyGuc5ecdIASbBsuXMo3q/Rs3/cnY.mLZP4tUgfGUOCUBlG', 'local', 'Panora');
 
 INSERT INTO connector_sets (id_connector_set, crm_hubspot, crm_zoho, crm_pipedrive, crm_attio, crm_zendesk, crm_close, tcg_zendesk, tcg_gorgias, tcg_front, tcg_jira, tcg_gitlab, fs_box, tcg_github) VALUES
-    ('1709da40-17f7-4d3a-93a0-96dc5da6ddd7', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE),
-    ('852dfff8-ab63-4530-ae49-e4b2924407f8', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE),
-    ('aed0f856-f802-4a79-8640-66d441581a99', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
+    ('1709da40-17f7-4d3a-93a0-96dc5da6ddd7', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE),
+    ('852dfff8-ab63-4530-ae49-e4b2924407f8', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE),
+    ('aed0f856-f802-4a79-8640-66d441581a99', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
 
 INSERT INTO projects (id_project, name, sync_mode, id_user, id_connector_set) VALUES
     ('1e468c15-aa57-4448-aa2b-7fed640d1e3d', 'Project 1', 'pull', '0ce39030-2901-4c56-8db0-5e326182ec6b', '1709da40-17f7-4d3a-93a0-96dc5da6ddd7'),


### PR DESCRIPTION
When creating a new account, an error happens [here](https://github.com/panoratech/Panora/blob/main/packages/api/src/%40core/projects/projects.service.ts#L62) due to missing fields on `connector_sets` table.

![image](https://github.com/user-attachments/assets/45059a9e-5b01-44d5-8f8f-53eb9e942005).


This PR add the missing columns into the migrations scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for new HR and ATS integrations with the addition of boolean columns for Gusto and BambooHR in the database.
	- Enhanced the data structure to accommodate expanded functionality for connector sets.

- **Improvements**
	- Increased the number of boolean flags for existing entries in the connector_sets table, allowing for more detailed configuration options.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->