### PR TITLE
Stores api data in remote_data field

### DIFF
--- a/packages/api/src/ticketing/account/services/front/mappers.ts
+++ b/packages/api/src/ticketing/account/services/front/mappers.ts
@@ -63,6 +63,7 @@ export class FrontAccountMapper implements IAccountMapper {
       name: account.name,
       domains: account.domains.flat(),
       field_mappings: field_mappings,
+      remote_data: account
     };
 
     return unifiedAccount;

--- a/packages/api/src/ticketing/account/services/zendesk/mappers.ts
+++ b/packages/api/src/ticketing/account/services/zendesk/mappers.ts
@@ -60,6 +60,7 @@ export class ZendeskAccountMapper implements IAccountMapper {
       remote_id: String(account.id),
       name: account.name,
       domains: account.domain_names,
+      remote_data: account
     };
 
     return unifiedAccount;


### PR DESCRIPTION
fixes #676 
 
Stores api output in remote_data field, for zendesk and front in tieckting pillar account section. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `remote_data` property in the unified account representation for both the FrontAccountMapper and ZendeskAccountMapper, enabling access to original account information alongside transformed fields. 

- **Enhancements**
	- Improved context and reference capabilities for account data, facilitating better integration with other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->