### PR TITLE
Consider drive root to be a folder when syncing onedrive/sharepoint

### DIFF
--- a/packages/api/src/filestorage/folder/services/onedrive/index.ts
+++ b/packages/api/src/filestorage/folder/services/onedrive/index.ts
@@ -83,7 +83,20 @@ export class OnedriveService implements IFolderService {
         },
       });
 
-      let result = [],
+      // get root folder
+      const rootFolderData = await axios.get(
+        `${connection.account_url}/v1.0/me/drive/root`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.cryptoService.decrypt(
+              connection.access_token,
+            )}`,
+          },
+        },
+      );
+
+      let result = [rootFolderData.data],
         depth = 0,
         batch = [remote_folder_id];
 

--- a/packages/api/src/filestorage/folder/services/onedrive/types.ts
+++ b/packages/api/src/filestorage/folder/services/onedrive/types.ts
@@ -55,6 +55,8 @@ export interface OnedriveFolderInput {
   readonly createdBy?: IdentitySet;
   /** Identity of the user, device, and application that last modified the item. Read-only. */
   readonly lastModifiedBy?: IdentitySet;
+  /** If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive. */
+  readonly root?: any;
 }
 
 /**

--- a/packages/api/src/filestorage/folder/services/sharepoint/index.ts
+++ b/packages/api/src/filestorage/folder/services/sharepoint/index.ts
@@ -80,7 +80,20 @@ export class SharepointService implements IFolderService {
         },
       });
 
-      let result = [],
+      // get root folder
+      const rootFolderData = await axios.get(
+        `${connection.account_url}/drive/root`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.cryptoService.decrypt(
+              connection.access_token,
+            )}`,
+          },
+        },
+      );
+
+      let result = [rootFolderData.data],
         depth = 0,
         batch = [remote_folder_id];
 
@@ -104,7 +117,7 @@ export class SharepointService implements IFolderService {
               },
             );
 
-            // Add permissions (shared link is also included in permissions in one-drive)
+            // Add permissions (shared link is also included in permissions in SharePoint)
             // await Promise.all(
             //   resp.data.value.map(async (driveItem) => {
             //     const resp = await axios.get(

--- a/packages/api/src/filestorage/folder/services/sharepoint/types.ts
+++ b/packages/api/src/filestorage/folder/services/sharepoint/types.ts
@@ -55,6 +55,8 @@ export interface SharepointFolderInput {
   readonly createdBy?: IdentitySet;
   /** Identity of the user, device, and application that last modified the item. Read-only. */
   readonly lastModifiedBy?: IdentitySet;
+  /** If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive. */
+  readonly root?: any;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to retrieve root folder data from OneDrive and SharePoint, enhancing folder management capabilities.
	- Added optional `root` property to `OnedriveFolderInput` and `SharepointFolderInput` interfaces for better handling of folder structures.

- **Documentation**
	- Updated comments to clarify permissions associated with shared links in SharePoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->