### PR TITLE
Update quick-start.mdx: corrected typo. for "software"

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -32,7 +32,7 @@ Let's now create our first magic link!
         You'll be asked for two informations: an `Origin User Email` (of the user
         you're creating the link for) and an `Origin User Identifier`. The `Origin
         User Identifier` is the id of the user you're inviting, as represented in your
-        sofwtare. If you already have created a [Linked User](/recipes/import-existing-users) you have the option to select
+        software. If you already have created a [Linked User](/recipes/import-existing-users) you have the option to select
         it.
       </Step>
       <Step>Click `Generate`</Step>


### PR DESCRIPTION
On line 35, in sub-step 4 of step 1 (Getting access to your users data) there was a typographical mistake for word "software" Wrong: sofwtare
Corrected as: software
Kindly approve this simple typo. fix.
- Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Quickstart Guide for improved clarity with minor spelling and punctuation corrections.
	- Enhanced formatting for better readability while maintaining the original structure and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->