### PR TITLE
fix: updated docker base image to node:20-alpine3.21

### DIFF
--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -1,10 +1,10 @@
 # run directly from the repo root directory
 # docker build -f ./apps/webapp/Dockerfile .
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 # Turbo: Prepare a standalone workspace for docker
 FROM base AS builder
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 RUN apk update
 
 # Set pnpm
@@ -23,7 +23,7 @@ RUN ls -la ./out/full/apps/webapp
 # =======================================================================
 # Install Deps and build project using PNPM
 FROM base AS installer
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 RUN apk update
 # Set pnpm
 ENV PNPM_HOME="/pnpm"
@@ -47,8 +47,6 @@ RUN corepack enable
 
 WORKDIR /app
 
-RUN ls -la 
-
 # First install the dependencies (as they change less often)
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
@@ -64,4 +62,3 @@ COPY --from=builder ./app/out/full/ .
 RUN pnpm run build
 
 CMD cd /app/apps/webapp/ && pnpm run start
-

--- a/apps/webapp/Dockerfile.dev
+++ b/apps/webapp/Dockerfile.dev
@@ -1,9 +1,9 @@
 # run directly from the repo root directory
 # docker build -f ./apps/webapp/Dockerfile.dev .
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 RUN apk update
 
 # Set pnpm

--- a/apps/webapp/Dockerfile.slim
+++ b/apps/webapp/Dockerfile.slim
@@ -1,61 +1,57 @@
-FROM node:20-alpine AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat && \
-    corepack enable
+# Alpine image
+FROM node:20-alpine3.21 AS alpine
+RUN apk update
+RUN apk add --no-cache libc6-compat openssl
+
+# Setup pnpm and turbo on the alpine base
+FROM alpine as base
+RUN npm install pnpm turbo --global
+RUN pnpm config set store-dir ~/.pnpm-store
+
+# Prune projects
+FROM base AS pruner
+ARG PROJECT
 
 WORKDIR /app
-
-# Install Turbo
-RUN pnpm add -g turbo@1.13.4
-
-# Copy necessary files for turbo prune
 COPY . .
-
-# Prune the workspace
 RUN turbo prune --scope=webapp --docker
 
-# Installer stage
-FROM base AS installer
+# Build the project
+FROM base AS builder
+ARG PROJECT
+
 WORKDIR /app
 
-# Copy pruned files
-COPY --from=base /app/out/json/ .
-COPY --from=base /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=base /app/out/full/ .
+# Copy lockfile and package.json's of isolated subworkspace
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=pruner /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=pruner /app/out/json/ .
 
-# Install dependencies
-RUN pnpm install --shamefully-hoist
+# First install the dependencies (as they change less often)
+RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm install --frozen-lockfile
 
-# Build shared package first
-RUN cd packages/shared && pnpm run build
+# Copy source code of isolated subworkspace
+COPY --from=pruner /app/out/full/ .
 
-# Build the webapp
-RUN pnpm run build --filter=webapp...
+RUN turbo build --filter=webapp
+RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm prune --prod --no-optional
+RUN rm -rf ./**/*/src
 
-# Runner stage
-FROM node:20-alpine AS runner
-WORKDIR /app
+# Final image
+FROM alpine AS runner
+ARG PROJECT
 
-# Don't run production as root
 RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN adduser --system --uid 1001 nodejs
+USER nodejs
 
-# Copy necessary files
-COPY --from=installer /app/apps/webapp/.next/standalone ./
-COPY --from=installer /app/apps/webapp/.next/static ./apps/webapp/.next/static
-COPY --from=installer /app/apps/webapp/public ./apps/webapp/public
+WORKDIR /app
+COPY --from=builder --chown=nodejs:nodejs /app .
+WORKDIR /app/apps/webapp
 
-# Copy package.json files
-COPY --from=installer /app/apps/webapp/package.json ./package.json
-
-# Install only production dependencies
-
-USER nextjs
-
-ENV NODE_ENV=production
+ARG PORT=8080
 ENV PORT=8090
-
+ENV NODE_ENV=production
 EXPOSE 8090
 
-CMD ["node", "server.js"]
+CMD node dist/main

--- a/apps/webapp/src/app/(Dashboard)/api-keys/page.tsx
+++ b/apps/webapp/src/app/(Dashboard)/api-keys/page.tsx
@@ -177,7 +177,7 @@ export default function Page() {
             >
               <PlusCircle className="h-3.5 w-3.5" />
               <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-                Create New Api Key
+                Create API key
               </span>
             </Button>
             </DialogTrigger>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,7 +100,7 @@ services:
       WRIKE_TICKETING_CLOUD_CLIENT_SECRET: ${WRIKE_TICKETING_CLOUD_CLIENT_SECRET}
       ASANA_TICKETING_CLOUD_CLIENT_ID: ${ASANA_TICKETING_CLOUD_CLIENT_ID}
       ASANA_TICKETING_CLOUD_CLIENT_SECRET: ${ASANA_TICKETING_CLOUD_CLIENT_SECRET}
-      PENNYLANE_ACCOUNTING_CLOUD_CLIENT_ID: ${PENNYLANE_ACCOUNTING_CLOUD_CLIENT_ID}
+      PENNYLANE_ACCOUNTING_CLOUD_CLIENT_ID: ${PENNYLANE_ACCOUNTING_CLOUD_CcLIENT_ID}
       PENNYLANE_ACCOUNTING_CLOUD_CLIENT_SECRET: ${PENNYLANE_ACCOUNTING_CLOUD_CLIENT_SECRET}
       FRESHBOOKS_ACCOUNTING_CLOUD_CLIENT_ID: ${FRESHBOOKS_ACCOUNTING_CLOUD_CLIENT_ID}
       FRESHBOOKS_ACCOUNTING_CLOUD_CLIENT_SECRET: ${FRESHBOOKS_ACCOUNTING_CLOUD_CLIENT_SECRET}
@@ -170,28 +170,9 @@ services:
       PH_TELEMETRY: ${PH_TELEMETRY}
       SALESFORCE_CRM_CLOUD_CLIENT_ID: ${SALESFORCE_CRM_CLOUD_CLIENT_ID}
       SALESFORCE_CRM_CLOUD_CLIENT_SECRET: ${SALESFORCE_CRM_CLOUD_CLIENT_SECRET}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-      JINA_API_KEY: ${JINA_API_KEY}
-      COHERE_API_KEY: ${COHERE_API_KEY}
       AWS_S3_REGION: ${AWS_S3_REGION}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      UNSTRUCTURED_API_KEY: ${UNSTRUCTURED_API_KEY}
-      UNSTRUCTURED_API_URL: ${UNSTRUCTURED_API_URL} 
-      PINECONE_API_KEY: ${PINECONE_API_KEY}
-      PINECONE_INDEX_NAME: ${PINECONE_INDEX_NAME}
-      QDRANT_BASE_URL: ${QDRANT_BASE_URL}
-      QDRANT_API_KEY: ${QDRANT_API_KEY}
-      QDRANT_COLLECTION_NAME: ${QDRANT_COLLECTION_NAME}
-      CHROMADB_URL: ${CHROMADB_URL}
-      CHROMADB_COLLECTION_NAME: ${CHROMADB_COLLECTION_NAME}
-      WEAVIATE_URL: ${WEAVIATE_URL}
-      WEAVIATE_API_KEY: ${WEAVIATE_API_KEY}
-      WEAVIATE_CLASS_NAME: ${WEAVIATE_CLASS_NAME}
-      TURBOPUFFER_API_KEY: ${TURBOPUFFER_API_KEY}
-      MILVUS_ADDRESS: ${MILVUS_ADDRESS}
-      MILVUS_COLLECTION_NAME: ${MILVUS_COLLECTION_NAME}
-
     restart: unless-stopped
     ports:
       - 3000:3000
@@ -203,7 +184,7 @@ services:
     volumes:
       - .:/app
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 1000 # Try launching the API service as long as possible. Required for other services to start
@@ -251,24 +232,9 @@ services:
       - backend
       - frontend
 
-  magic-link-frontend:
-    build:
-      dockerfile: ./apps/magic-link/Dockerfile.dev
-      context: ./
-      args:
-        VITE_BACKEND_DOMAIN: http://localhost:3000
-        VITE_WEBAPP_DOMAIN: http://localhost
-    restart: always
-    ports:
-      - 81:5173
-    depends_on:
-      api:
-        condition: service_healthy
-    networks:
-      - backend
-      - frontend
-    volumes:
-      - .:/app
+  # # # # # # # # # # 
+  # Developer tools #
+  # # # # # # # # # # 
 
   # pgadmin:
   #   image: dpage/pgadmin4
@@ -313,29 +279,9 @@ services:
   #   volumes:
   #     - ./docs/:/app
 
-  minio:
-    image: minio/minio
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - minio_storage:/data
-    environment:
-      MINIO_ROOT_USER: myaccesskey13
-      MINIO_ROOT_PASSWORD: mysecretkey12
-    command: server --console-address ":9001" /data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    networks:
-      - backend
-
 volumes:
   local_pgdata:
   pgadmin-data:
-  minio_storage:
 
 networks:
   frontend:

--- a/docker-compose.source.yml
+++ b/docker-compose.source.yml
@@ -247,23 +247,6 @@ services:
     networks:
       - backend
       - frontend
-
-  magic-link-frontend:
-    build:
-      dockerfile: ./apps/magic-link/Dockerfile
-      context: ./
-      args:
-        VITE_BACKEND_DOMAIN: ${NEXT_PUBLIC_BACKEND_DOMAIN}
-        VITE_WEBAPP_DOMAIN: ${NEXT_PUBLIC_WEBAPP_DOMAIN}
-    restart: always 
-    ports:
-      - 81:80
-    #depends_on:
-      #api:
-        #condition: service_healthy
-    networks:
-      - backend
-      - frontend
   
 networks:
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,19 +217,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-      
-
-  magic-link-frontend:
-    image: panora.docker.scarf.sh/panoradotdev/frontend-magic-links:selfhosted
-    restart: always
-    ports:
-      - 81:80
-    depends_on:
-      postgres:
-        condition: service_healthy
-    networks:
-      - backend
-      - frontend 
 
   webapp-next:
     image: panora.docker.scarf.sh/panoradotdev/frontend-webapp:selfhosted
@@ -251,28 +238,6 @@ services:
     networks:
       - backend
       - frontend
-      
-  minio:
-    image: minio/minio
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - minio_storage:/data
-    environment:
-      MINIO_ROOT_USER: myaccesskey13
-      MINIO_ROOT_PASSWORD: mysecretkey12
-    command: server --console-address ":9001" /data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    networks:
-      - backend
-
-volumes:
-  minio_storage:
 
 networks:
   frontend:

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,9 +1,9 @@
 # run directly from the repo root directory
 # docker build -f ./packages/api/Dockerfile .
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 RUN apk update
 
 # Set pnpm
@@ -19,7 +19,7 @@ RUN turbo prune api --docker
 # =======================================================================
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 RUN apk update
 # Set pnpm
 ENV PNPM_HOME="/pnpm"
@@ -42,7 +42,7 @@ RUN pnpm run build
 
 # ========================================================================
 FROM base AS runner
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 
 WORKDIR /app
 

--- a/packages/api/Dockerfile.dev
+++ b/packages/api/Dockerfile.dev
@@ -1,9 +1,9 @@
 # run directly from the repo root directory
 # docker build -f ./packages/api/Dockerfile.dev .
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 RUN apk update
 
 # Set pnpm

--- a/packages/api/Dockerfile.pnpm-build
+++ b/packages/api/Dockerfile.pnpm-build
@@ -4,11 +4,11 @@
 # 3/ run with: docker run -v $(pwd):/app/ package_builder
 ################################################
 
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 RUN apk update
 
 # Set pnpm

--- a/packages/api/Dockerfile.pnpm-installer
+++ b/packages/api/Dockerfile.pnpm-installer
@@ -5,10 +5,10 @@
 # example: docker run -v $(pwd):/app/ -e PACKAGE_NAME=@stripe/stripe-js package_installer
 ################################################
 
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 RUN apk update
 
 # Set pnpm

--- a/packages/api/Dockerfile.pnpm-lint
+++ b/packages/api/Dockerfile.pnpm-lint
@@ -4,11 +4,11 @@
 # 3/ run with: docker run -v $(pwd):/app/ package_linter
 ################################################
 
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 
 # =======================================================================
 FROM base AS linter
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 RUN apk update
 
 # Set pnpm

--- a/packages/api/Dockerfile.validate-connectors
+++ b/packages/api/Dockerfile.validate-connectors
@@ -5,10 +5,10 @@
 # note: use lowercase for object and vertical values
 ################################################
 
-FROM node:20-alpine AS base
+FROM node:20-alpine3.21 AS base
 # =======================================================================
 FROM base AS builder
-RUN apk add --no-cache libc6-compat netcat-openbsd curl
+RUN apk add --no-cache libc6-compat netcat-openbsd curl openssl
 RUN apk update
 
 # Set pnpm


### PR DESCRIPTION
Updating docker base image following as base image does not include openssl anymore

Details:
https://github.com/nodejs/docker-node/issues/2175 
https://github.com/prisma/prisma/issues/25817 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated button text in the API keys management interface.
  
- **Bug Fixes**
  - Improved error logging for API key retrieval.

- **Chores**
  - Updated base images to a more specific version across multiple Dockerfiles.
  - Enhanced package installation by adding `openssl` to various Dockerfiles.
  
- **Refactor**
  - Restructured Dockerfile stages for the web application to streamline the build process and improve dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->